### PR TITLE
Add client credentials grant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdk-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ProdataKey pdk.io API Client Library for Javascript",
   "scripts": {
     "test": "mocha -r src/test-setup.js -r babel-register src/**/*.spec.js",

--- a/readme.md
+++ b/readme.md
@@ -30,16 +30,6 @@ import { authenticate } from 'pdk';
 const tokenset = await authenticate(client_id, client_secret);
 ```
 
-These operations also return Promises if this form of async operation handling is preferred, or if `await` is not available in the JS environment.
-
-```javascript
-import { authenticate } from 'pdk';
-authenticate(client_id, client_secret)
-  .then(tokenset => {
-    // use tokenset here
-  });
-```
-
 ### Creating a session with the Auth API
 
 Once calling `authenticate` to get an authentication context, use `makesession` to create a session with the auth API.
@@ -48,22 +38,13 @@ This session will automatically manage the authentication token lifetime, using 
 See the auth API documentation for operations and data types available here.
 
 ```javascript
-import { authenticate, makesession } from 'pdk';
+import { authenticate, makeSession } from 'pdk';
 
 try {
-  const session = await makesession(await authenticate(client_id, client_secret));
+  const session = await makeSession(await authenticate(client_id, client_secret));
 } catch(err) {
   console.log(`Error authenticating: ${err.msg}`);
 }
-```
-
-Same as above, in Promise style:
-
-```javascript
-import { authenticate, makesession } from 'pdk';
-const session = authenticate(client_id, client_secret)
-  .then(makesession)
-  .catch(err => console.log(`Error authenticating: ${err.msg}`));
 ```
 
 This `session` function is a thin facade around [got](https://github.com/sindresorhus/got) that allows easily making authenticated requests, options are passed on to got.
@@ -85,16 +66,16 @@ See the panel API documentation for operations and data types available here.
 **Note**: The term *panel* in the documentation is synonymous with the PDK cloud node hardware.
 
 ```javascript
-import { authenticate, makesession, makepanelsession } from 'pdk';
+import { authenticate, makeSession, makePanelSession } from 'pdk';
 
 // Authenticate and create a session with the auth API
-const session = await makesession(await authenticate(client_id, client_secret));
+const session = await makeSession(await authenticate(client_id, client_secret));
 
 // Get a panel document from the auth API
 const panel = await session('panels/1070BBB');
 
 // Create an authenticated session with the panel
-const panelsession = await makepanelsession(session, panel);
+const panelsession = await makePanelSession(session, panel);
 
 // Retrieve an entity from the panel API
 const me = await panelsession('people/123');
@@ -122,6 +103,17 @@ stream.emit('command', {
   body: { doorId: 6 },
   id
 });
+```
+
+### Client Authentication
+
+Applications that support the client credentials authentication flow can use the `authenticateclient`, in the same way as the `authenticate` method.
+
+```javascript
+import { authenticateclient, makesession } from 'pdk';
+
+// Authenticate and create a session with the auth API
+const session = await makesession(await authenticateclient(client_id, client_secret));
 ```
 
 ### Functions

--- a/src/authenticator.js
+++ b/src/authenticator.js
@@ -2,6 +2,7 @@ import { Issuer } from 'openid-client';
 import { createServer } from 'http';
 import defaultOpener from 'opener';
 import Debug from 'debug';
+import { authenticateclient } from './clientauthenticator';
 
 let debug = Debug('pdk:authenticator');
 
@@ -121,6 +122,8 @@ export async function authenticate({ client_id, client_secret, scope = 'openid',
   }
 }
 
+export { authenticateclient };
 export default {
-  authenticate
+  authenticate,
+  authenticateclient
 };

--- a/src/clientauthenticator.js
+++ b/src/clientauthenticator.js
@@ -1,0 +1,50 @@
+import { Issuer } from 'openid-client';
+import Debug from 'debug';
+
+let debug = Debug('pdk:clientauthenticator');
+
+//FIXME: Remove this default http options setter after 'got' library will release new version
+Issuer.defaultHttpOptions = {form: true};
+
+export async function authenticateclient({ client_id, client_secret, issuer = 'https://accounts.pdk.io' }) {
+  debug(`Authenticating as client_id: ${client_id}`);
+
+  const pdkIssuer = await Issuer.discover(issuer);
+  const client = new pdkIssuer.Client({ client_id, client_secret });
+  client.CLOCK_TOLERANCE = 20;
+
+  debug(`Got configured oidc client`);
+
+  let token_set = { };
+
+  // This must conform to the token_set interface
+  // see session.js for usage
+  const oauthtoken_set = async () => {
+    if(!token_set.id_token) {
+      debug(`Initial fetch of oauthtoken`);
+      await oauthtoken_set.refresh()
+    }
+
+    //TODO: Check expiration time of token and optimistically renew it
+
+    return token_set;
+  };
+
+  oauthtoken_set.refresh = async () => {
+    debug(`Getting token with client credentials`);
+
+    token_set = await client.grant({ grant_type: 'client_credentials' });
+
+    debug(`Got fresh token: ${JSON.stringify(token_set)}`);
+  };
+
+  oauthtoken_set.revoke = async () => {
+    if(token_set.id_token) {
+      client.revoke(token_set.id_token);
+    }
+  };
+
+  // Force initial load of the oauthtoken_set
+  await oauthtoken_set.refresh();
+  return oauthtoken_set;
+}

--- a/src/examples/clientinventory.js
+++ b/src/examples/clientinventory.js
@@ -7,7 +7,7 @@ import p from 'asyncp';
 import Debug from 'debug';
 
 let debug = Debug('pdk:inventory');
-const SAIDP_URI = process.env.PDK_SAIDP_URI || 'https://accounts.pdk.io';
+const IDP_URI = process.env.IDP_URI || 'https://accounts.pdk.io';
 
 (async function() {
   let tokenset;
@@ -15,14 +15,14 @@ const SAIDP_URI = process.env.PDK_SAIDP_URI || 'https://accounts.pdk.io';
     tokenset = await authenticateclient({
       client_id: process.env.PDK_CLIENT_ID,
       client_secret: process.env.PDK_CLIENT_SECRET,
-      issuer: SAIDP_URI
+      issuer: IDP_URI
     });
   } catch(err) {
     debug(`There was an error authenticating: ${err.message}`);
     return;
   }
 
-  let authsession = makeSession(tokenset, url.resolve(SAIDP_URI, `api/`));
+  let authsession = makeSession(tokenset, url.resolve(IDP_URI, `api/`));
 
   // Connect to the panel and itemize asset info
   // Panel => InventoriedPanel

--- a/src/examples/inventory.js
+++ b/src/examples/inventory.js
@@ -9,6 +9,7 @@ import p from 'asyncp';
 import Debug from 'debug';
 
 let debug = Debug('pdk:inventory');
+const IDP_URI = process.env.IDP_URI || 'https://accounts.pdk.io';
 
 (async function() {
   let tokenset;
@@ -16,6 +17,7 @@ let debug = Debug('pdk:inventory');
     tokenset = await authenticate({
       client_id: process.env.PDK_CLIENT_ID,
       client_secret: process.env.PDK_CLIENT_SECRET,
+      issuer: IDP_URI,
       opener: opener
     });
   } catch(err) {
@@ -23,7 +25,7 @@ let debug = Debug('pdk:inventory');
     return;
   }
 
-  let authsession = makeSession(tokenset);
+  let authsession = makeSession(tokenset, url.resolve(IDP_URI, `api/`));
 
   // Connect to the panel and itemize asset info
   // Panel => InventoriedPanel

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,3 @@
-import authenticator from './authenticator';
-import session from './session';
-
-export default {
-  authenticator,
-  session
-}
+export * from './authenticator';
+export * from './session';
+export { makeSession as makePanelSession } from './panelApi';


### PR DESCRIPTION
Add support for client credentials authentication flow

To authenticate using client credentials, use the `authenticateClient` function instead of the `authenticate` function to retrieve an auth session using just the OAuth client credentials.

https://pdkauthapi.docs.apiary.io/#introduction/authentication-flows/client-credentials-flow