### PR TITLE
Add ability to specify default http options

### DIFF
--- a/src/authenticators/client.js
+++ b/src/authenticators/client.js
@@ -17,9 +17,12 @@ let debug = Debug('pdk:auth:client');
 export const clientauth = ({
   client_id,
   client_secret,
-  issuer = 'https://accounts.pdk.io'
+  issuer = 'https://accounts.pdk.io',
+  default_http_options = {}
 }) =>
 async () => {
+  Issuer.defaultHttpOptions = default_http_options;
+
   debug(`Authenticating as client_id: ${client_id}`);
 
   const pdkIssuer = await Issuer.discover(issuer);

--- a/src/authenticators/client.js
+++ b/src/authenticators/client.js
@@ -21,7 +21,8 @@ export const clientauth = ({
   default_http_options = {}
 }) =>
 async () => {
-  Issuer.defaultHttpOptions = default_http_options;
+  // merge provided default http options with PDK defaults and set it to the Issuer object
+  Issuer.defaultHttpOptions = Object.assign({timeout: 10000, retries: 1}, default_http_options);
 
   debug(`Authenticating as client_id: ${client_id}`);
 

--- a/src/authenticators/user.js
+++ b/src/authenticators/user.js
@@ -29,7 +29,8 @@ export const userauth = ({
   default_http_options = {}
 }) =>
 async () => {
-  Issuer.defaultHttpOptions = default_http_options
+  // merge provided default http options with PDK defaults and set it to the Issuer object
+  Issuer.defaultHttpOptions = Object.assign({timeout: 10000, retries: 1}, default_http_options)
 
   debug(`Authenticating id: ${client_id}`)
 

--- a/src/authenticators/user.js
+++ b/src/authenticators/user.js
@@ -25,9 +25,12 @@ export const userauth = ({
   issuer = 'https://accounts.pdk.io',
   opener = defaultOpener,
   closer,
-  refresh_token
+  refresh_token,
+  default_http_options = {}
 }) =>
 async () => {
+  Issuer.defaultHttpOptions = default_http_options
+
   debug(`Authenticating id: ${client_id}`)
 
   const pdkIssuer = await Issuer.discover(issuer)

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-const require = require("esm")(module)
+require = require("esm")(module)
 module.exports = require("./main.js")


### PR DESCRIPTION
It will be useful to be able to override default http options for OpenID Connect client. Currently, http timeout is set to 1500ms, and it is a very small value. Possibly, we can override all necessary http options, not only timeout.


Also, I fixed a problem with index.js in this PR - 'const' shouldn't be used there.